### PR TITLE
Update snap_wrapper.c

### DIFF
--- a/src/snap_wrapper.c
+++ b/src/snap_wrapper.c
@@ -230,6 +230,7 @@ SEXP snap_bridging_R(SEXP sE, SEXP sn, SEXP sm, SEXP sMPI, SEXP srank) {
 #endif
     if (REAL(sBC) == NULL) {
         REprintf("Rank %d: error!\n", rank);
+        UNPROTECT(1);
         return NULL;
     }
   }


### PR DESCRIPTION
Change in line 233, required by CRAN:
Dear maintainer,
 
please have a look at PROTECT bug reports from rchk for your package. There seem to be real bugs:
 
Function snap_bridging_R
  [PB] has possible protection stack imbalance influenceR/src/snap_wrapper.c:253
 
function snap_bridging_R is missing an UNPROTECT(1) in snap_wrapper.c, before returning from line 233.
 
The rchk reports are available on the CRAN results page for each package, see Additional issues/rchk.
 
Thanks,
Tomas